### PR TITLE
Host blog on Heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _drafts/
 .DS_Store
 node_modules
 .sass-cache
+.asset-cache

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-ruby '2.2.3'
+ruby "2.2.3"
 
-gem 'jekyll'
-gem 'jekyll-paginate'
+gem "rake"
+gem "jekyll"
+gem "jekyll-paginate"

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ ruby "2.2.3"
 
 gem "rake"
 gem "jekyll"
+gem "jekyll-assets"
 gem "jekyll-paginate"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+ruby '2.2.3'
+
+gem 'jekyll'
+gem 'jekyll-paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,41 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorator (0.1)
+    ffi (1.9.10)
+    jekyll (3.0.1)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.3.0)
+      sass (~> 3.2)
+    jekyll-watch (1.3.0)
+      listen (~> 3.0)
+    kramdown (1.9.0)
+    liquid (3.0.6)
+    listen (3.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    rb-fsevent (0.9.6)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
+    sass (3.4.19)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  jekyll-paginate
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
+    rake (10.4.2)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -36,6 +37,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-paginate
+  rake
 
 BUNDLED WITH
    1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.3.8)
     colorator (0.1)
+    fastimage (1.8.0)
+      addressable (~> 2.3, >= 2.3.5)
     ffi (1.9.10)
     jekyll (3.0.1)
       colorator (~> 0.1)
@@ -12,6 +15,11 @@ GEM
       mercenary (~> 0.3.3)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
+    jekyll-assets (2.0.2)
+      fastimage (~> 1.8)
+      jekyll (~> 3.0)
+      sprockets (~> 3.3)
+      sprockets-helpers (~> 1.2)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
@@ -23,6 +31,7 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
+    rack (1.6.4)
     rake (10.4.2)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
@@ -30,12 +39,17 @@ GEM
     rouge (1.10.1)
     safe_yaml (1.0.4)
     sass (3.4.19)
+    sprockets (3.4.0)
+      rack (> 1, < 3)
+    sprockets-helpers (1.2.1)
+      sprockets (>= 2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   jekyll
+  jekyll-assets
   jekyll-paginate
   rake
 

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: jekyll build

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: jekyll build
+web: bundle exec jekyll build && ./bin/boot

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec jekyll build && ./bin/boot
+web: bin/boot

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,8 @@
 # Owen Ou's Blog
 
-This is the data for my geek blog. It uses [Jekyll][1] as the blog engine. 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+This is the data for my geek blog. It uses [Jekyll][1] as the blog engine.
 
 # License
 
@@ -10,4 +12,4 @@ This work is licensed under [Creative Commons Attribution-NonCommercial-NoDerivs
 [2]: http://creativecommons.org/licenses/by-nc-nd/3.0/
 
 
-Copyright 2009-2014 Jingwen Owen Ou
+Copyright 2009-2016 Jingwen Owen Ou

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require "rubygems"
+require "rake"
+
+namespace :assets do
+  desc "Precompile Jekyll site"
+  task :precompile do
+    sh "jekyll build"
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -5,5 +5,12 @@ namespace :assets do
   desc "Precompile Jekyll site"
   task :precompile do
     sh "jekyll build"
+
+    # Purge all Fastly cache on every asset:precompile if Fastly is set up
+    # Hopefully Heroku Deploy Hooks can run a script later
+    if ENV["FASTLY_API_KEY"] && ENV["FASTLY_SERVICE_ID"]
+      puts "Purging all Fastly cache..."
+      sh "curl -s -X POST -H 'Fastly-Key: #{ENV["FASTLY_API_KEY"]}' https://api.fastly.com/service/#{ENV["FASTLY_SERVICE_ID"]}/purge_all"
+    end
   end
 end

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ author: "Owen Ou"
 email: "jingweno@gmail.com"
 description: "I'm a hacker."
 baseurl: ""
-url: "http://owenou.com"
+url: "https://owenou.com"
 logourl: "/assets/img/bloglogo.jpg"
 fa-logo: "fa-flag-o"
 paginate: 5

--- a/_config.yml
+++ b/_config.yml
@@ -36,3 +36,6 @@ permalink: /:year/:month/:day/:title
 
 gems:
   - jekyll-paginate
+
+exclude:
+  - vendor

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ theme_always_show_nav: false
 # SASS Settings
 # DO NOT MODIFY
 sass:
- sass_dir: "assets/css/"
+ sass_dir: "assets/css"
  style: :compressed
 
 # Build Settings
@@ -35,7 +35,18 @@ markdown: kramdown
 permalink: /:year/:month/:day/:title
 
 gems:
+  - jekyll-assets
   - jekyll-paginate
+
+assets:
+  cdn: https://owenou-herokuapp-com.global.ssl.fastly.net
+  digest: true
+  sources:
+    - assets/css
+    - assets/img
+    - assets/js
+    - images/theme
+    - images/posts
 
 exclude:
   - vendor

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,5 +1,5 @@
 <div class="profile">
-  {% if site.logourl != "" %}<img src="{{ site.logourl }}" class="profileimage" alt="user">{% endif %}
+  {% img "bloglogo.jpg" class:"profileimage" alt:"user" %}
   <h4>{{ site.author }}</h4>
   <p>{{ site.description }}</p>
   <div class="postprofile">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,11 +12,11 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
       <link rel="alternate" type="application/rss+xml" href="{{ site.url }}/feed.xml">
-      <link rel="shortcut icon" type="image/png" href="/images/theme/owen.png">
+      <link rel="shortcut icon" type="image/png" href="{% asset_path "owen.png" %}">
       <link rel="prefetch" href="{{ site.url }}">
       <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
-      <link rel="stylesheet" href="{{ "/assets/css/init.css" | prepend: site.baseurl }}">
+      {% stylesheet "app.css" %}
       <link href='//fonts.googleapis.com/css?family=Domine:700|Open+Sans:400,600|Source+Code+Pro:500' rel='stylesheet' type='text/css'>
       <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
   </head>
@@ -39,7 +39,6 @@
         'autoload_comments': {{ site.theme_autoload_comments }}
       };
     </script>
-    <script async type="text/javascript" src="{{ "/assets/js/theme.min.js" | prepend: site.baseurl }}"></script>
-
+    {% javascript "theme.js" async %}
   </body>
 </html>

--- a/_posts/eclipse/_posts/2010-04-07-adaptive-implementations-with-eclipses-optional-plugin-dependencies.markdown
+++ b/_posts/eclipse/_posts/2010-04-07-adaptive-implementations-with-eclipses-optional-plugin-dependencies.markdown
@@ -12,7 +12,7 @@ Let's get started with an example: When a HTML file is clicked, it should be ope
 
 * First, we need to add the WTP UI component as an *optional* dependency.
 
-	![push method](/images/posts/optional_dependencies.png){: width="304" height="307"}
+	![push method]({% asset_path "optional_dependencies.png" %}){: width="304" height="307"}
 
 	The MANIFEST.MF should look something like this:
 

--- a/_posts/eclipse/_posts/2010-04-12-pushing-adaptive-implementations-with-eclipse-extension-points.markdown
+++ b/_posts/eclipse/_posts/2010-04-12-pushing-adaptive-implementations-with-eclipse-extension-points.markdown
@@ -10,11 +10,11 @@ A week ago, I blogged about [implementing adaptive components using Eclipse's op
 
 However, the implementation is far from enjoyable: our main plugin knows everything about WTP! In other words, in order to specify the query, our main plugin has to know about WTP, hence containing environment-specific implementations. The following graph shows the dependency:
 	
-![pull method](/images/posts/pull.png){: width="300" height="200"}
+![pull method]({% asset_path "pull.png" %}){: width="300" height="200"}
 
 The reason causing this environment-specific coupling is that our main plugin uses the **pull** method to retrieve the HTML editor implementations from WTP (code snippet goes [here][1]). To solve this, we can [inverse the control][4] and have another plugin to **push** specific implementations to the main plugin.
 
-![push method](/images/posts/push.png){: width="400" height="252"}
+![push method]({% asset_path "push.png" %}){: width="400" height="252"}
 
 Equinox has already offered a very powerful tool for this purpose: [extension points][5]. In the dependency graph above, we separate the concerns by creating an adaptor plugin between the main plugin and the WTP plugin. We declare its dependency on WTP as optional to make sure the plugin will be installed on clients even if the WTP dependency is missing. If somehow WTP is installed in the future, the adaptor will automatically hook it up. Besides, we define an extension point in the main plugin so that the adaptor plugin knows what to contribute and where to contribute.
 

--- a/_posts/eclipse/_posts/2010-07-08-introducing-eclipse-rap.markdown
+++ b/_posts/eclipse/_posts/2010-07-08-introducing-eclipse-rap.markdown
@@ -6,7 +6,7 @@ categories: eclipse rap
 
 RAP, what? The Eclipse community is expanding its range to Hip Hop :)? Not exactly, although there is a chance. [Eclipse Rich Ajax Platform][4] (RAP) is a framework that empowers developers to build rich web clients “the Eclipse way.” <!--more--> From the latest [Helios download][5], RAP Tooling has become a default component of the RCP bundle:
 
-![Eclipse rap download](/images/posts/rap_download.png){: width="463" height="37"}
+![Eclipse rap download]({% asset_path "rap_download.png" %}){: width="463" height="37"}
 
 So what exactly is the Eclipse paradigm? Can we benefit from it?
 
@@ -16,13 +16,13 @@ RAP is to the web as RCP to the desktop. It inherits all the goodness from RCP s
 
 The following is the architecture of RAP:
 
-![rap architecture](/images/posts/rap_archi.png){: width="521" height="158"}
+![rap architecture]({% asset_path "rap_archi.png" %}){: width="521" height="158"}
 
 This architecture determines that developers can bring their RCP applications to the web with a single code base, also called single sourcing[^1]. Like building a RCP application, building a RAP application is a process of building plug-ins and bundles: On the UI side, contributing widget plug-ins; On the server side, since it is powered by [server-side Equinox][7], contributing servlet plug-ins. Unsurprisingly, it also inherits the benefits of any OSGi application such as dynamically adding/removing bundles.
 
 This architecture also determines that RAP is a server-centric AJAX framework[^3]. As indicated below, in a server-centric framework, the application is hosted on the application server and all processing is done on the server. The client browser is only used for data presentation. Consequently, it leaves small footprints on browsers: it waits for instructions from the server to create corresponding widgets on demand. In contrast, client-centric framework such as GWT statically compiles all widgets beforehand.
 
-![server centric vs client centric](/images/posts/server_centric_client_centric.png){: width="468" height="331"}
+![server centric vs client centric]({% asset_path "server_centric_client_centric.png" %}){: width="468" height="331"}
 
 Both methods have pros and cons. Server-centric frameworks handle all communication  automatically and leaves as few JavaScript codes on the browsers as possible, hence potentially having less security holes on the browsers. Client-centric frameworks are more flexible but require more work to step deep into low-level implementations of client-to-server communication, e.g., figuring out how to update widgets effectively in an asynchronous callback.
 

--- a/_posts/eclipse/_posts/2011-02-05-running-a-single-junit-test-in-eclipse.markdown
+++ b/_posts/eclipse/_posts/2011-02-05-running-a-single-junit-test-in-eclipse.markdown
@@ -11,11 +11,11 @@ if there is a test suite with multiple tests, when running a single unit test, e
 
 Like the example below, running *testOne* will trigger running the rest of the tests in the suite which are grouped under the "**Unrooted Tests**" node. This is quite irritating sometimes since running unexpected tests may slow down the workflow if they take time to finish. It's also quite confusing since programmers get unwanted test results. Some of my coworkers solve this problem by commenting out unwanted tests each time before running a test. However, it's not very effective and it's error-prone.
 
-![A single test triggers multiple tests](/images/posts/a_single_test_triggers_multiple_tests.png)
+![A single test triggers multiple tests]({% asset_path "a_single_test_triggers_multiple_tests.png" %})
 
 This happens mainly because we are running JUnit 3 tests with the JUnit 4 runner. Before version 4.6, the [JUnit 4 runner][1] seems to have the problem of falling back to run a single JUnit 3 test.
 
-![Running JUnit 3 tests with JUnit 4 runner](/images/posts/running_junit3_with_junit4_runner.png)
+![Running JUnit 3 tests with JUnit 4 runner]({% asset_path "running_junit3_with_junit4_runner.png" %})
 
 So...the solution is quite simple:
 

--- a/_posts/git/_posts/2011-03-23-git-up-perforce-with-git-p4.markdown
+++ b/_posts/git/_posts/2011-03-23-git-up-perforce-with-git-p4.markdown
@@ -12,7 +12,7 @@ Git is particularly good at this aspect which provides tons of [bridges][1] to o
 
 <!--more-->
 
-![git-p4 bridge](/images/posts/git-p4.jpeg)
+![git-p4 bridge]({% asset_path "git-p4.jpeg" %})
 
 ## Setting up the Perforce command line client
 
@@ -87,7 +87,7 @@ Normally we check in a .gitignore file to ignore files that we don't want to che
 
 There is no magic happening with git-p4. What it does is simply invoking the p4 command line tool to download sources to local, and then clone a Git repository out of it. You can simply verify this by typing "git branch -a":
 
-![under the hook of git-p4](/images/posts/Terminal.jpeg)
+![under the hook of git-p4]({% asset_path "Terminal.jpeg" %})
 
 You may be amazed once again by how flexible the design of Git is which makes it possible to bridge to multiple VCS!
 

--- a/_posts/git/_posts/2012-01-13-ten-things-you-didnt-know-git-and-github-could-do.markdown
+++ b/_posts/git/_posts/2012-01-13-ten-things-you-didnt-know-git-and-github-could-do.markdown
@@ -18,22 +18,22 @@ increase your day-to-day productivity.
 On your source code browsing page, press **t** to enter the fuzzy file
 finder mode:
 
-![GitHub Shortcuts File Finder](/images/posts/github_shortcut_file_finder.png)
+![GitHub Shortcuts File Finder]({% asset_path "github_shortcut_file_finder.png" %})
 
 On your repository's home page, press **w** to quickly filter
 branches:
 
-![GitHub Shortcuts Filter Branch](/images/posts/github_shortcut_filter_branch.png)
+![GitHub Shortcuts Filter Branch]({% asset_path "github_shortcut_filter_branch.png" %})
 
 On any GitHub page, press **?** to show the list of shortcuts applied to a particular page:
 
-![GitHub Shortcuts](/images/posts/github_shortcuts.png)
+![GitHub Shortcuts]({% asset_path "github_shortcuts.png" %})
 
 ### ignoring whitespace: ?w=1
 
 Add **?w=1** any diff URL to trim whitespace:
 
-![GitHub Trim Whitespace](/images/posts/github_trim_whitespace.png)
+![GitHub Trim Whitespace]({% asset_path "github_trim_whitespace.png" %})
 
 ### commits by range: master@{time}..master
 
@@ -45,7 +45,7 @@ of commits since yesterday by using format like **master@{1.day.ago}...master**.
 [https://github.com/rails/rails/compare/master@{1.day.ago}...master](https://github.com/rails/rails/compare/master@{1.day.ago}...master),
 for example, gets all commits since yesterday for the Rails project:
 
-![GitHub Advanced Compare View](/images/posts/github_advanced_compare_view.png)
+![GitHub Advanced Compare View]({% asset_path "github_advanced_compare_view.png" %})
 
 ### commits by author: ?author=github_handle
 
@@ -54,7 +54,7 @@ You can filter commits by author in the commit view by appending param
 [https://github.com/dynjs/dynjs/commits/master?author=jingweno](https://github.com/dynjs/dynjs/commits/master?author=jingweno)
 shows a list of my commits to the [Dynjs](http://dynjs.org/) project:
 
-![GitHub Filter Commits By Author](/images/posts/github_filter_by_author.png)
+![GitHub Filter Commits By Author]({% asset_path "github_filter_by_author.png" %})
 
 ### .diff & .patch
 
@@ -64,14 +64,14 @@ link [https://github.com/rails/rails/compare/master@{1.day.ago}...master.patch](
 gets the patch for all the commits since yesterday in the Rails
 project:
 
-![GitHub Diff Patch](/images/posts/github_diff_patch.png)
+![GitHub Diff Patch]({% asset_path "github_diff_patch.png" %})
 
 ### email reply
 
 You can comment directly by replying to the email received from GitHub
 instead of commenting on the website. GitHub will route your reply correctly:
 
-![GitHub Reply Email](/images/posts/github_email_reply.png)
+![GitHub Reply Email]({% asset_path "github_email_reply.png" %})
 
 ### line linking
 
@@ -79,14 +79,14 @@ In any file view, when you click one line or multiple lines by pressing
 **SHIFT**, the URL will change to reflect your selections. This is very
 handy for sharing the link to a chunk of code with your teammates:
 
-![GitHub Line Linking](/images/posts/github_line_linking.png)
+![GitHub Line Linking]({% asset_path "github_line_linking.png" %})
 
 ### subscribing peoples
 
 Mentioning users in pull requests, issues or any comment will subscribe them to all
 subsequent notifications:
 
-![GitHub Subscribe Peoples](/images/posts/github_subscribe_peoples.png)
+![GitHub Subscribe Peoples]({% asset_path "github_subscribe_peoples.png" %})
 
 ### autolink
 
@@ -96,7 +96,7 @@ or issue number from another repository with the format of
 **user/repo@sha1** or **user/repo#1** respectively. The following is an
 example of autolinking a sha in a comment:
 
-![GitHub Auto Link](/images/posts/github_auto_link.png)
+![GitHub Auto Link]({% asset_path "github_auto_link.png" %})
 
 ### hub
 

--- a/_posts/hci/_posts/2010-07-05-why-code-navigation-sucks-on-most-scm-web-interface.markdown
+++ b/_posts/hci/_posts/2010-07-05-why-code-navigation-sucks-on-most-scm-web-interface.markdown
@@ -8,11 +8,11 @@ I am not surprised that you feel the same. It sucks to navigate codes on most so
 
 1. **The display of files in most SCM's web interface is not in a tree, but in a list**. Files are in a tree structure; displaying them as a list is definitely a mismatch! The consequence of converting a tree structure to a list one is that the file context is lost during navigation. I believe you must feel annoying when clicking back and forth in order to find more than one file on [GitHub][1]'s web interface: 
 
-	![GitHub](/images/posts/github.png){: width="559" height="220"}
+	![GitHub]({% asset_path "github.png" %}){: width="559" height="220"}
 
 2. **There is a disconnection between opened file's context and opened file's content**. Take <a href="http://code.google.com/" target="_blank">Google Code</a>'s web interface as an example, although its display of files is in a tree structure, but after a file is opened, the context where the file belongs to is gone: only the path of the file is still kept:
 
-	![Google Code](/images/posts/google_code.png){: width="560" height="560"}
+	![Google Code]({% asset_path "google_code.png" %}){: width="560" height="560"}
 	
 3. **Being impossible to open multiple files at once**. File is a module to separate concerns in almost all programming languages. At most of the time, reading code only from one file is not informative enough. In a programming language sense, files have connections to each other and being able to show related file modules at once is critical to understand the application. Moreover, we have been used to exploring pages with multiple tabs on a browser, and have been used to navigate codes with multiple viewers in an IDE. This feature is definitely a must!
 

--- a/_posts/java/_posts/2010-07-20-patching-with-class-shadowing-and-maven.markdown
+++ b/_posts/java/_posts/2010-07-20-patching-with-class-shadowing-and-maven.markdown
@@ -22,7 +22,7 @@ It tells the class loader that patch.jar is loaded before ootb.jar, hence any cl
 
 Here is an example we are going to build. HelloWorldProxy is a *proxy* artifact that exports its classpath in such an order that classes in HelloWorldPatch are replacing classes in HelloWorld. HelloWorldTest depends on HelloWorldProxy and doesn’t know which implementation (HelloWorld or HelloWorldPatch) HelloWorldProxy is exporting. The dependency graph is as followed:
 
-![example dependency](/images/posts/maven_example_dep.png){: width="447" height="245"}
+![example dependency]({% asset_path "maven_example_dep.png" %}){: width="447" height="245"}
 
 In the pom.xml of HelloWorldProxy, it has two dependencies and we put HelloWorldPatch before HelloWorld, since we would like to see classes in HelloWorldPatch replacing the ones in HelloWorld. As of Maven 2.0.9, the ordering of dependencies on the classpath is [preserved][5]. The code snippet is as followed:
 
@@ -64,7 +64,7 @@ We also need to make sure HelloWorldProxy exports the two jars in the  Class-Pat
 
 Run “mvn package” in HelloWorldProxy and take a look at the generated MANIFEST.MF:
 
-![manifest](/images/posts/maven_manifest.png){: width="594" height="102"}
+![manifest]({% asset_path "maven_manifest.png" %}){: width="594" height="102"}
 
 Voila! That’s what we expect! HelloWorldPatch takes precedence over HelloWorld on HelloWorldProxy’s classpath!
 

--- a/_posts/ruby/_posts/2011-09-24-poeaa-on-rails.md
+++ b/_posts/ruby/_posts/2011-09-24-poeaa-on-rails.md
@@ -40,7 +40,7 @@ to go.
 and a database. It typically creates [Domain Model][7] objects by populating
 their attributes from the database.
 
-![Data Mapper](/images/posts/data_mapper.png)
+![Data Mapper]({% asset_path "data_mapper.png" %})
 
 Assuming we are building an e-commerce platform, we get a store object by
 going through the store mapper which connects to the database:
@@ -304,7 +304,7 @@ pattern:
 >
 > Two Step View deals with this problem by splitting the transformation into two stages. The first transforms the model data into a logical presentation without any special formatting; the second converts that logical presentation with the actual formatting needed. ...
 
-![Two Step View](/images/posts/two_step_view.png)
+![Two Step View]({% asset_path "two_step_view.png" %})
 
 From the above diagram, the multi-storefront example can be reimplemented with the Two Step
 View pattern. The process is in two steps. The first step is to

--- a/app.json
+++ b/app.json
@@ -3,6 +3,12 @@
   "description": "This is the blog of Owen Ou",
   "website": "https://owenou.com",
   "repository": "https://github.com/jingweno/jingweno.github.io",
+  "env": {
+    "JEKYLL_ENV": {
+      "description": "Jekyll Environment. It affects asset compilation. Details see https://github.com/jekyll/jekyll-assets#configuration.",
+      "value": "production"
+    }
+  },
   "buildpacks": [
     {
 

--- a/app.json
+++ b/app.json
@@ -5,11 +5,11 @@
   "repository": "https://github.com/jingweno/jingweno.github.io",
   "buildpacks": [
     {
-      "url": "heroku/ruby"
-    },
-    {
 
       "url": "https://github.com/hone/heroku-buildpack-static.git"
+    },
+    {
+      "url": "heroku/ruby"
     }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,15 @@
+{
+  "name": "Owen Ou's blog",
+  "description": "This is the blog of Owen Ou",
+  "website": "https://owenou.com",
+  "repository": "https://github.com/jingweno/jingweno.github.io",
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    },
+    {
+
+      "url": "https://github.com/hone/heroku-buildpack-static.git"
+    }
+  ]
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,6 +1,3 @@
----
----
-
 @import "normalize";
 
 @import "mixin";

--- a/static.json
+++ b/static.json
@@ -2,5 +2,19 @@
   "root": "_site/",
   "https_only": true,
   "clean_urls": true,
-  "error_page": "404.html"
+  "error_page": "404.html",
+  "headers": {
+    "/**": {
+      "Cache-Control": "private, no-store, no-cache, must-revalidate, proxy-revalidate",
+      "Pragma": "no-cache",
+      "Expires": "Sat, 05 Nov 1955 00:00:00 PST",
+      "Strict-Transport-Security": "max-age=86400; includeSubDomains;",
+      "X-Download-Options": "noopen",
+      "X-Content-Type-Options": "nosniff",
+      "X-Frame-Options": "SAMEORIGIN",
+      "X-XSS-Protection": "1; mode=block"
+    },
+    "/assets/**": { "Cache-Control": "public, max-age=512000" },
+    "/images/**": { "Cache-Control": "public, max-age=512000" }
+  }
 }

--- a/static.json
+++ b/static.json
@@ -2,8 +2,5 @@
   "root": "_site/",
   "https_only": true,
   "clean_urls": true,
-  "error_page": "404.html",
-  "routes": {
-    "/**": "index.html"
-  }
+  "error_page": "404.html"
 }

--- a/static.json
+++ b/static.json
@@ -5,16 +5,13 @@
   "error_page": "404.html",
   "headers": {
     "/**": {
-      "Cache-Control": "private, no-store, no-cache, must-revalidate, proxy-revalidate",
+      "Cache-Control": "public, s-maxage=2592000, max-age=86400",
       "Pragma": "no-cache",
-      "Expires": "Sat, 05 Nov 1955 00:00:00 PST",
       "Strict-Transport-Security": "max-age=86400; includeSubDomains;",
       "X-Download-Options": "noopen",
       "X-Content-Type-Options": "nosniff",
       "X-Frame-Options": "SAMEORIGIN",
       "X-XSS-Protection": "1; mode=block"
-    },
-    "/assets/**": { "Cache-Control": "public, max-age=512000" },
-    "/images/**": { "Cache-Control": "public, max-age=512000" }
+    }
   }
 }

--- a/static.json
+++ b/static.json
@@ -2,6 +2,7 @@
   "root": "_site/",
   "https_only": true,
   "clean_urls": true,
+  "error_page": "404.html",
   "routes": {
     "/**": "index.html"
   }

--- a/static.json
+++ b/static.json
@@ -1,6 +1,6 @@
 {
   "root": "_site/",
-  "https_only": false,
+  "https_only": true,
   "clean_urls": true,
   "routes": {
     "/**": "index.html"

--- a/static.json
+++ b/static.json
@@ -5,13 +5,14 @@
   "error_page": "404.html",
   "headers": {
     "/**": {
-      "Cache-Control": "public, s-maxage=2592000, max-age=86400",
+      "Cache-Control": "private, no-store, no-cache, must-revalidate, proxy-revalidate",
       "Pragma": "no-cache",
       "Strict-Transport-Security": "max-age=86400; includeSubDomains;",
       "X-Download-Options": "noopen",
       "X-Content-Type-Options": "nosniff",
       "X-Frame-Options": "SAMEORIGIN",
       "X-XSS-Protection": "1; mode=block"
-    }
+    },
+    "/assets/**": { "Cache-Control": "public, s-maxage=2592000, max-age=86400" }
   }
 }

--- a/static.json
+++ b/static.json
@@ -1,0 +1,8 @@
+{
+  "root": "_site/",
+  "https_only": false,
+  "clean_urls": true,
+  "routes": {
+    "/**": "index.html"
+  }
+}


### PR DESCRIPTION
Moving https://owenou.com from GitHub Pages to Heroku and caching assets with Fastly.

**How it works**

The Jekyll static site is compiled as part of the [heroku-buildpack-ruby's asset precompile](https://github.com/heroku/heroku-buildpack-ruby/blob/master/lib/language_pack/ruby.rb#L789-L803) and is served with [heroku-buildpack-static](https://github.com/hone/heroku-buildpack-static) using Nginx. Assets are cached with Fastly and cache is purged on each Heroku push at asset precompilation. Asset URLs are rewritten to point to Fastly CDN by [jekyll-assets](https://github.com/jekyll/jekyll-assets#configuration).

Alternatively, to maximize performance, Fastly can be put in front the Heroku Dyno to serve everything: DNS (`owenou.com`) -> Fastly CDN edge (`owenou-herokuapp-com.global.ssl.fastly.net`) -> Heroku Dyno. But [setting up a custom cert on Fastly is expensive](https://www.fastly.com/pricing) so in the case of serving a blog, only caching assets with Fastly is sufficient.

**Advantages**

* HTTPS support. This has been [a long time request](https://github.com/isaacs/github/issues/156) for GitHub Pages.
* Caching with CDN. Thanks to `heroku-buildpack-static` [cache headers can be easily defined](https://github.com/hone/heroku-buildpack-static#custom-headers).

Now my blog is very fast(ly) :smile_cat:!

Fastly serves everything:

![screen shot 2015-11-22 at 8 51 13 am](https://cloud.githubusercontent.com/assets/169064/11324986/57c8aa58-90f6-11e5-8db3-70fe2c9834f4.png)

Fastly only serves assets:

![screen shot 2015-11-22 at 12 23 01 pm](https://cloud.githubusercontent.com/assets/169064/11326090/cfdcfc38-9114-11e5-8384-de1dcec638cf.png)


**Disadvantages**

* Cost. Heroku Free Dyno ($0) + Heroku SSL Domain ($20) + Fastly Fast Plan ($50) = $70, while GitHub Pages is free...It will be even more expensive to have custom cert on Fastly. However, it can be totally free on Heroku for casual use without custom SSL domain and Fastly.

**Wish List**

* A generator to set things up, e.g., `heroku static:init --jekyll`
* [Heroku Deploy Hooks](https://devcenter.heroku.com/articles/deploy-hooks) can run a script in the Dyno so that purging Fastly cache is easier. Currently I'm [putting this in the `assets:precompile` step](https://github.com/jingweno/jingweno.github.io/blob/heroku/Rakefile#L9-L14) as part of the Heroku Ruby buildpack.